### PR TITLE
Forms plan search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,3 @@ script:
   - bundle exec rspec spec
 rvm:
   - 2.0
-  - 2.1
-  - 2.2
-  - rbx-2

--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rspec", "~> 3.2"
-  spec.add_development_dependency "rspec-junklet", "~> 2.0"
+  spec.add_development_dependency "rspec", ">= 3.2"
+  spec.add_development_dependency "rspec-junklet", ">= 2.0"
   spec.add_development_dependency "webmock", "~> 1.11"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "pry"
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "railties"
 
   spec.add_runtime_dependency "rest-client", "~> 1.6"
-  spec.add_runtime_dependency "hashie", "~> 2.0.2"
+  spec.add_runtime_dependency "hashie", ">= 2.0.2"
   spec.add_runtime_dependency "settingslogic"
   spec.add_runtime_dependency "activesupport"
 end

--- a/lib/cover_my_meds/client/forms.rb
+++ b/lib/cover_my_meds/client/forms.rb
@@ -10,6 +10,16 @@ module CoverMyMeds
       data['forms'].map { |d| Hashie::Mash.new(d) }
     end
 
+    def form_search_by_plan plan_hash, drug_id, state, version=CURRENT_VERSION
+      params = plan_hash.merge(
+        drug_id: drug_id,
+        state: state,
+        v: version
+      )
+      data = forms_request GET, params: params
+      data['forms'].map { |d| Hashie::Mash.new(d) }
+    end
+
     def get_form form_id, version = CURRENT_VERSION
       data = forms_request GET, params: { v: version }, path: form_id
       Hashie::Mash.new(data['form'])

--- a/lib/cover_my_meds/client/forms.rb
+++ b/lib/cover_my_meds/client/forms.rb
@@ -5,24 +5,28 @@ module CoverMyMeds
     CURRENT_VERSION = 1
 
     def form_search form, drug_id, state, version=CURRENT_VERSION
-      params = {q: form, drug_id: drug_id, state: state, v: version}
-      data = forms_request GET, params: params
-      data['forms'].map { |d| Hashie::Mash.new(d) }
+      search_with_args({q: form}, drug_id, state, version)
     end
 
     def form_search_by_plan plan_hash, drug_id, state, version=CURRENT_VERSION
-      params = plan_hash.merge(
+      search_with_args(plan_hash, drug_id, state, version)
+    end
+
+    def get_form form_id, version = CURRENT_VERSION
+      data = forms_request GET, params: { v: version }, path: form_id
+      Hashie::Mash.new(data['form'])
+    end
+
+    private
+
+    def search_with_args(query_args, drug_id, state, version)
+      params = query_args.merge(
         drug_id: drug_id,
         state: state,
         v: version
       )
       data = forms_request GET, params: params
       data['forms'].map { |d| Hashie::Mash.new(d) }
-    end
-
-    def get_form form_id, version = CURRENT_VERSION
-      data = forms_request GET, params: { v: version }, path: form_id
-      Hashie::Mash.new(data['form'])
     end
   end
 end

--- a/lib/cover_my_meds/version.rb
+++ b/lib/cover_my_meds/version.rb
@@ -1,3 +1,3 @@
 module CoverMyMeds
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 end

--- a/spec/forms_spec.rb
+++ b/spec/forms_spec.rb
@@ -7,14 +7,14 @@ describe 'Forms' do
 
   describe '#form_search' do
     let(:drug_id) { '093563' }
-    let(:form)    { 'anthem'}
-    let(:state)   { 'oh'}
-    let(:drug)    { 'Boniva'}
+    let(:form)    { 'anthem' }
+    let(:state)   { 'oh' }
+    let(:drug)    { 'Boniva' }
     let(:version) { 1 }
 
     before do
       stub_request(:get, "https://#{api_id}:@api.covermymeds.com/forms/?drug_id=#{drug_id}&state=#{state}&q=#{form}&v=#{version}")
-      .to_return(status: 200, body: fixture('forms.json'))
+        .to_return(status: 200, body: fixture('forms.json'))
     end
 
     it 'returns matching forms' do
@@ -33,14 +33,14 @@ describe 'Forms' do
   describe '#form_search_with_plan' do
     let(:drug_id) { '093563' }
     let(:bin)     { '610053' }
-    let(:pcn)     { 'BCBSOGA' }
-    let(:state)   { 'oh'}
-    let(:drug)    { 'Boniva'}
+    let(:pcn)     { 'BCBSOG' }
+    let(:state)   { 'oh' }
+    let(:drug)    { 'Boniva' }
     let(:version) { 1 }
 
     before do
       stub_request(:get, "https://#{api_id}:@api.covermymeds.com/forms/?drug_id=#{drug_id}&state=#{state}&bin=#{bin}&pcn=#{pcn}&v=#{version}")
-      .to_return(status: 200, body: fixture('forms.json'))
+       .to_return(status: 200, body: fixture('forms.json'))
     end
 
     it 'returns matching forms' do

--- a/spec/forms_spec.rb
+++ b/spec/forms_spec.rb
@@ -5,11 +5,11 @@ describe 'Forms' do
   let(:client) { CoverMyMeds::Client.new(api_id) }
   let(:version){ 1 }
 
-  context 'search' do
+  describe '#form_search' do
     let(:drug_id) { '093563' }
-    let(:form)    {'anthem'}
-    let(:state)   {'oh'}
-    let(:drug)    {'Boniva'}
+    let(:form)    { 'anthem'}
+    let(:state)   { 'oh'}
+    let(:drug)    { 'Boniva'}
     let(:version) { 1 }
 
     before do
@@ -30,7 +30,33 @@ describe 'Forms' do
     end
   end
 
-  context 'get' do
+  describe '#form_search_with_plan' do
+    let(:drug_id) { '093563' }
+    let(:bin)     { '610053' }
+    let(:pcn)     { 'BCBSOGA' }
+    let(:state)   { 'oh'}
+    let(:drug)    { 'Boniva'}
+    let(:version) { 1 }
+
+    before do
+      stub_request(:get, "https://#{api_id}:@api.covermymeds.com/forms/?drug_id=#{drug_id}&state=#{state}&bin=#{bin}&pcn=#{pcn}&v=#{version}")
+      .to_return(status: 200, body: fixture('forms.json'))
+    end
+
+    it 'returns matching forms' do
+      forms = client.form_search_by_plan({bin: bin, pcn: pcn}, drug_id, state)
+      single_form = forms.first
+      expect(single_form.id).to               eq 15257
+      expect(single_form.href).to             eq 'https://staging.api.covermymeds.com/forms/15257'
+      expect(single_form.name).to             eq 'blue_cross_blue_shield_georgia_general'
+      expect(single_form.description).to      eq 'Anthem Non-Preferred Medications Request Form'
+      expect(single_form.directions).to       eq 'Anthem Prior Authorization Form for Non-Preferred Medications Request '
+      expect(single_form.request_form_id).to  eq 'blue_cross_blue_shield_georgia_general_15257'
+      expect(single_form.thumbnail_url).to    eq 'https://navinet.covermymeds.com/forms/pdf/thumbs/90/blue_cross_blue_shield_georgia_general_15257.jpg'
+    end
+  end
+
+  describe '#get_form' do
     let(:form_id) { 'humana_tracleer_4' }
     let(:version) { 1 }
 


### PR DESCRIPTION
Adds a new method, #form_search_with_plan, to the Forms client.  This performs a BIN/PCN/RXGROUP search instead of a query search.

Also relaxed restrictions on RSpec and Hashie in the gem spec, since Hashie was causing conflicts with other gems and there seemed to be no reason RSpec had to be restricted to 3.2.