### PR TITLE
Suppress ruby 2.1 and 2.2 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,3 @@ script:
   - bundle exec rspec spec
 rvm:
   - 2.0
-  - 2.1
-  - 2.2
-  - rbx-2


### PR DESCRIPTION
Get CI green for now.  IDK why ruby 2.1 and 2.2 builds would fail in this way.