### PR TITLE
custom error class outputs http_method and rest_resource

### DIFF
--- a/lib/cover_my_meds/api_request.rb
+++ b/lib/cover_my_meds/api_request.rb
@@ -39,7 +39,7 @@ module CoverMyMeds
       body = block_given? ? yield : {}
       rest_resource.send http_method, body
     rescue RestClient::Exception => e
-      raise Error::HTTPError.new(e.http_code, e.http_body)
+      raise Error::HTTPError.new(e.http_code, e.http_body, http_method, rest_resource)
     end
 
     def api_uri host, path, params

--- a/lib/cover_my_meds/error.rb
+++ b/lib/cover_my_meds/error.rb
@@ -10,9 +10,11 @@ module CoverMyMeds
       end
 
       def message
-        "#{@status}: #{@error_json}\n"+
-        "in response to:\n"+
-        "#{@http_method.upcase} #{@rest_resource}\n"
+        <<-EOS.gsub(/^ {10}/, "")
+          #{@status}: #{@error_json}
+          in response to:
+          #{@http_method.upcase} #{@rest_resource}
+        EOS
       end
 
       attr_reader :status, :error_json, :http_method, :rest_resource

--- a/lib/cover_my_meds/error.rb
+++ b/lib/cover_my_meds/error.rb
@@ -2,16 +2,20 @@ module CoverMyMeds
   module Error
     class HTTPError < StandardError
 
-      def initialize status, message
+      def initialize status, message, http_method, rest_resource
         @status = status
         @error_json = message
+        @http_method = http_method
+        @rest_resource = rest_resource
       end
 
       def message
-        "#{@status}: #{@error_json}"
+        "#{@status}: #{@error_json}\n"+
+        "in response to:\n"+
+        "#{@http_method.upcase} #{@rest_resource}\n"
       end
 
-      attr_reader :status, :error_json
+      attr_reader :status, :error_json, :http_method, :rest_resource
 
     end
 

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -4,10 +4,14 @@ module CoverMyMeds
   module Error
     describe HTTPError do
 
-      subject { described_class.new status, error_json }
+      subject { described_class.new status, error_json, http_method, rest_resource }
 
       specify "#message" do
-        expect(subject.message).to eq("#{status}: #{error_json}")
+        expect(subject.message).to eq(
+          "#{status}: #{error_json}\n"+
+          "in response to:\n"+
+          "#{http_method.upcase} #{rest_resource}\n"
+        )
       end
 
       specify "#status" do
@@ -18,11 +22,23 @@ module CoverMyMeds
         expect(subject.error_json).to eq(error_json)
       end
 
+      specify "#http_method" do
+        expect(subject.http_method).to eq(http_method)
+      end
+
+      specify "#rest_resource" do
+        expect(subject.rest_resource).to eq(rest_resource)
+      end
+
       let(:status) { 404 }
 
       let(:error_json) do
         Hash[errors: [{ debug: "Nothing to see here, move along." }]].to_json
       end
+
+      let(:http_method) { 'post' }
+
+      let(:rest_resource) { 'https://<url>/<route>/?<params>&v=<version>' }
 
     end
   end


### PR DESCRIPTION
WIP

After getting an error like this:
```
    RuntimeError:
       Error with form search: 422: {"errors":[{"code":422204,"message":"drug not found.","debug":null}]}
```

it would be helpful to have the URL endpoint that was hit. Adding this block in `client/forms.rb`:
```ruby
 28       data = begin
 29                forms_request GET, params: params
 30              rescue CoverMyMeds::Error::HTTPError => e
 31                RestClient.log = Logger.new(STDOUT)
 32                forms_request GET, params: params
 33              end
```

produced this output when it errored out:
```bash
RestClient.get "https://*.covermymeds.com/forms/?drug_id=024002&q=BCBS&state=OH&v=1", "Accept"=>"*/*; q=0.5, application/xml", "Accept-Encoding"=>"gzip, deflate"
# => 422 UnprocessableEntity | application/json 69 bytes
F
```

Maybe the begin/rescue block could be moved into all the `*_request` methods defined in this gem. However, it makes the request twice. 

- [x] How to capture the url during a request, and output it only when an error is raised?
- [ ] How to add authentication to the url as it's being output?

