### PR TITLE
allows fixnum paths

### DIFF
--- a/lib/cover_my_meds/meta/host_and_path.rb
+++ b/lib/cover_my_meds/meta/host_and_path.rb
@@ -44,7 +44,7 @@ module CoverMyMeds
           params     =  options[:params]
           auth       =  options[:auth]
           host_name  =  public_send("#{api_name}_host".to_sym)
-          full_path  =  public_send("#{api_name}_path".to_sym) + path
+          full_path  =  public_send("#{api_name}_path".to_sym) + path.to_s
 
           proxy_args = [ method, host_name, full_path, params, auth ]
           fail ArgumentError, "method, host_name or full_path can not be nil" if proxy_args.take(3).any?(&:nil?)

--- a/spec/meta/host_and_path_spec.rb
+++ b/spec/meta/host_and_path_spec.rb
@@ -1,5 +1,6 @@
 module CoverMyMeds::ExampleApiResources
   include CoverMyMeds::HostAndPath
+  include CoverMyMeds::ApiRequest
 end
 
 class AnyClass
@@ -37,6 +38,14 @@ describe AnyClass do
     it "should proxy for #request" do
       expect(subject).to receive(:request).with(:GET, "http://default-host.com", "/example-api-resources/", {v: 1})
       subject.example_api_resources_request(:GET, params: {v: 1})
+    end
+
+    context "when the path is a Fixnum" do
+      let(:path) { junk :int }
+      it "does not blow up" do
+        stub_request :get, %r{example-api-resources/#{path}}
+        expect { subject.example_api_resources_request(:get, path: path) }.to_not raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Fixes `TypeError: no implicit conversion of Fixnum into String` when passing in path as an integer.