### PR TITLE
Replace usage of rest-client with faraday

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ quickfix.out
 
 # to keep out api keys and secrets
 spec/support/cassettes/**
+/vendor

--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rspec", ">= 3.2"
   spec.add_development_dependency "rspec-junklet", ">= 2.0"
-  spec.add_development_dependency "webmock", "~> 1.11"
+  spec.add_development_dependency "webmock", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "dotenv"
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "railties"
 
   spec.add_runtime_dependency "faraday", "~> 0.9"
+  spec.add_runtime_dependency "typhoeus"
   spec.add_runtime_dependency "hashie", ">= 3.4.0"
   spec.add_runtime_dependency "settingslogic"
   spec.add_runtime_dependency "activesupport"

--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "railties"
 
-  spec.add_runtime_dependency "rest-client", "~> 1.8"
+  spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "hashie", ">= 3.4.0"
   spec.add_runtime_dependency "settingslogic"
   spec.add_runtime_dependency "activesupport"

--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "typhoeus"
+  spec.add_runtime_dependency "mime-types"
   spec.add_runtime_dependency "hashie", ">= 3.4.0"
-  spec.add_runtime_dependency "settingslogic"
   spec.add_runtime_dependency "activesupport"
 end

--- a/lib/cover_my_meds/api_request.rb
+++ b/lib/cover_my_meds/api_request.rb
@@ -6,6 +6,7 @@ require 'hashie'
 require 'active_support/core_ext/object/to_param'
 require 'active_support/core_ext/object/to_query'
 require 'cover_my_meds/error'
+require 'mime-types'
 
 
 module CoverMyMeds

--- a/lib/cover_my_meds/api_request.rb
+++ b/lib/cover_my_meds/api_request.rb
@@ -34,7 +34,7 @@ module CoverMyMeds
         request.options.timeout = DEFAULT_TIMEOUT
         request.params = params
         request.headers.merge! headers
-        request.body = yield if block_given?
+        request.body = block_given? ? yield : {}
       end
       raise Error::HTTPError.new(response.status, response.body, http_method, conn) unless response.success?
 

--- a/lib/cover_my_meds/api_request.rb
+++ b/lib/cover_my_meds/api_request.rb
@@ -1,4 +1,4 @@
-require 'rest-client'
+require 'faraday'
 require 'json'
 require 'hashie'
 require 'active_support/core_ext/object/to_param'
@@ -12,19 +12,22 @@ module CoverMyMeds
       params  = params.symbolize_keys
       headers = params.delete(:headers) || {}
 
-      tail = case auth_type
-        when :basic
-          { user: @username, password: @password, headers: headers }
-        when :bearer
-          { headers: { "Authorization" => "Bearer #{@username}+#{params.delete(:token_id)}" }.merge(headers) }
-        else
-          {}
+      conn = Faraday.new host
+      case auth_type
+      when :basic
+        conn.basic_auth @username, @password
+      when :bearer
+        conn.authorization :Bearer, "#{@username}+#{params.delete(:token_id)}"
       end
 
-      uri = api_uri(host, path, params)
-      rest_resource = RestClient::Resource.new(uri.to_s, tail)
+      response = conn.send http_method do |request|
+        request.url path
+        request.params = params
+        request.headers.merge! headers
+        request.body = yield if block_given?
+      end
+      raise Error::HTTPError.new(response.status, response.body, http_method, conn) unless response.success?
 
-      response = call_api http_method, rest_resource, &block
       parse_response response
     end
 
@@ -33,20 +36,6 @@ module CoverMyMeds
       JSON.parse(response.body)
     rescue JSON::ParserError
       response.body
-    end
-
-    def call_api http_method, rest_resource
-      body = block_given? ? yield : {}
-      rest_resource.send http_method, body
-    rescue RestClient::Exception => e
-      raise Error::HTTPError.new(e.http_code, e.http_body, http_method, rest_resource)
-    end
-
-    def api_uri host, path, params
-      URI.parse(host).tap do |uri|
-        uri.path  = path
-        uri.query = params.to_param
-      end
     end
   end
 end

--- a/lib/cover_my_meds/api_request.rb
+++ b/lib/cover_my_meds/api_request.rb
@@ -17,6 +17,8 @@ module CoverMyMeds
       headers = params.delete(:headers) || {}
 
       conn = Faraday.new host do |faraday|
+        faraday.request :multipart
+        faraday.request :url_encoded
         faraday.adapter :typhoeus
       end
       case auth_type

--- a/lib/cover_my_meds/client/indicators.rb
+++ b/lib/cover_my_meds/client/indicators.rb
@@ -6,7 +6,7 @@ module CoverMyMeds
 
     def post_indicators(prescription: prescription(), patient: patient(), payer: {}, prescriber: {}, version: CURRENT_VERSION)
       params = { prescription: prescription, prescriber: prescriber, patient: patient, payer: payer }
-      data = indicators_request POST, params: { v: version, headers: { content_type: :json } } do
+      data = indicators_request POST, params: { v: version, headers: { content_type: "application/json" } } do
         params.to_json
       end
       Hashie::Mash.new(data)
@@ -14,7 +14,7 @@ module CoverMyMeds
 
     def search_indicators(prescriptions: prescriptions(), patient: {}, payer: {}, prescriber: {}, version: CURRENT_VERSION)
       params = { prescriptions: Array(prescriptions), prescriber: prescriber, patient: patient, payer: payer }
-      data = indicators_request POST, path: 'search/', params: { v: version, headers: { content_type: :json } } do
+      data = indicators_request POST, path: 'search/', params: { v: version, headers: { content_type: "application/json" } } do
         params.to_json
       end
       Hashie::Mash.new(data)

--- a/lib/cover_my_meds/version.rb
+++ b/lib/cover_my_meds/version.rb
@@ -1,3 +1,3 @@
 module CoverMyMeds
-  VERSION = "2.1.0"
+  VERSION = "3.0.0"
 end

--- a/spec/api_request_spec.rb
+++ b/spec/api_request_spec.rb
@@ -21,7 +21,7 @@ describe 'Request' do
 
   context 'get request with error' do
     before do
-      stub_request(:get, "#{scheme}#{api_id}:#{api_secret}@#{host}#{path}")
+      stub_request(:get, "#{scheme}#{host}#{path}").with(basic_auth: [api_id, api_secret])
       .to_return(status: 400, body: fixture('api_client_error.json'))
     end
 
@@ -33,7 +33,7 @@ describe 'Request' do
   context 'get request' do
     context 'non-json response' do
       before do
-        stub_request(:get, "#{scheme}#{api_id}:#{api_secret}@#{host}#{path}")
+        stub_request(:get, "#{scheme}#{host}#{path}").with(basic_auth: [api_id, api_secret])
         .to_return(status: 200, body: non_json_response)
       end
 
@@ -44,7 +44,7 @@ describe 'Request' do
 
     context 'json response' do
       before do
-        stub_request(:get, "#{scheme}#{api_id}:#{api_secret}@#{host}#{path}")
+        stub_request(:get, "#{scheme}#{host}#{path}").with(basic_auth: [api_id, api_secret])
         .to_return(status: 200, body: json_response)
       end
 

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -19,8 +19,9 @@ describe 'Consumer' do
     }
   end
   let!(:consumer_create_stub) do
-    stub_request(:post, "https://#{api_id}:#{api_secret}@api.covermymeds.com/consumers/?v=1").with(
-      body: { consumer: { description: description, email: email } }
+    stub_request(:post, "https://api.covermymeds.com/consumers/?v=1").with(
+      body: { consumer: { description: description, email: email } },
+      basic_auth: [api_id, api_secret]
     ).to_return(body: response.to_json)
   end
 

--- a/spec/credential_spec.rb
+++ b/spec/credential_spec.rb
@@ -8,8 +8,7 @@ describe 'Credential' do
   let(:npi)           { '1234567890' }
   let(:fax_number)    { '15552224444' }
   let(:email)         { 'ehrsystem@foo.dev' }
-  let(:auth)          { "#{api_id}:#{api_secret}" }
-  let(:api_url)       { "https://#{auth}@api.covermymeds.com/prescribers/credentials/?v=#{version}" }
+  let(:api_url)       { "https://api.covermymeds.com/prescribers/credentials/?v=#{version}" }
   let(:callback_url)  { 'https://foo.dev/callback' }
   let(:callback_verb) { 'POST' }
   let(:contact_hint) do
@@ -46,6 +45,7 @@ describe 'Credential' do
     before do
       stub_request(:post, api_url)
       .with(
+        basic_auth: [api_id, api_secret],
         body: credential_body,
       )
       .to_return( status: 201, body: fixture('post_credential.json'))
@@ -69,7 +69,7 @@ describe 'Credential' do
   end
 
   describe '#delete_credential' do
-    let(:api_url)                 { "https://#{auth}@api.covermymeds.com/prescribers/credentials/#{npi}" }
+    let(:api_url)                 { "https://api.covermymeds.com/prescribers/credentials/#{npi}" }
     let!(:delete_credential_stub) { stub_request(:delete, api_url).with(query: { v: version }).to_return(status: 204) }
 
     it 'deletes the credential' do

--- a/spec/drugs_spec.rb
+++ b/spec/drugs_spec.rb
@@ -9,8 +9,9 @@ describe 'Drugs' do
     let(:drug)    {'Boniva'}
     let(:version) { 1 }
     before do
-      stub_request(:get, "https://#{api_id}:@api.covermymeds.com/drugs/?q=#{drug}&v=#{version}").
-        to_return( status: 200, body: fixture('drugs.json'))
+      stub_request(:get, "https://api.covermymeds.com/drugs/?q=#{drug}&v=#{version}")
+        .with(basic_auth: [api_id, ''])
+        .to_return( status: 200, body: fixture('drugs.json'))
     end
 
     it 'makes methods from json' do
@@ -36,8 +37,9 @@ describe 'Drugs' do
     let(:version) { 1 }
 
     before do
-      stub_request(:get, "https://#{api_id}:@api.covermymeds.com/drugs/#{drug_id}?v=#{version}").
-        to_return( status: 200, body: fixture('drug.json'))
+      stub_request(:get, "https://api.covermymeds.com/drugs/#{drug_id}?v=#{version}")
+        .with(basic_auth: [api_id, ''])
+        .to_return( status: 200, body: fixture('drug.json'))
     end
 
     it 'makes methods from json' do

--- a/spec/forms_spec.rb
+++ b/spec/forms_spec.rb
@@ -13,7 +13,8 @@ describe 'Forms' do
     let(:version) { 1 }
 
     before do
-      stub_request(:get, "https://#{api_id}:@api.covermymeds.com/forms/?drug_id=#{drug_id}&state=#{state}&q=#{form}&v=#{version}")
+      stub_request(:get, "https://api.covermymeds.com/forms/?drug_id=#{drug_id}&state=#{state}&q=#{form}&v=#{version}")
+        .with(basic_auth: [api_id, ''])
         .to_return(status: 200, body: fixture('forms.json'))
     end
 
@@ -39,8 +40,9 @@ describe 'Forms' do
     let(:version) { 1 }
 
     before do
-      stub_request(:get, "https://#{api_id}:@api.covermymeds.com/forms/?drug_id=#{drug_id}&state=#{state}&bin=#{bin}&pcn=#{pcn}&v=#{version}")
-       .to_return(status: 200, body: fixture('forms.json'))
+      stub_request(:get, "https://api.covermymeds.com/forms/?drug_id=#{drug_id}&state=#{state}&bin=#{bin}&pcn=#{pcn}&v=#{version}")
+        .with(basic_auth: [api_id, ''])
+        .to_return(status: 200, body: fixture('forms.json'))
     end
 
     it 'returns matching forms' do
@@ -61,8 +63,9 @@ describe 'Forms' do
     let(:version) { 1 }
 
     before do
-      stub_request(:get, "https://#{api_id}:@api.covermymeds.com/forms/humana_tracleer_4?v=#{version}")
-      .to_return(status: 200, body: fixture('form.json'))
+      stub_request(:get, "https://api.covermymeds.com/forms/humana_tracleer_4?v=#{version}")
+        .with(basic_auth: [api_id, ''])
+        .to_return(status: 200, body: fixture('form.json'))
     end
 
     it 'returns matching forms' do

--- a/spec/indicator_spec.rb
+++ b/spec/indicator_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Indicators' do
   junklet :api_id, :api_secret, :bin, :pcn, :group_id
   let(:version) { 1 }
-  let(:uri) { "https://#{api_id}:#{api_secret}@api.covermymeds.com/indicators/?v=#{version}" }
+  let(:uri) { "https://api.covermymeds.com/indicators/?v=#{version}" }
   let(:client) { CoverMyMeds::Client.new(api_id, api_secret) }
   let(:prescription_payload) { Hash drug_id: '12345' }
   let(:payer_payload) { Hash bin: bin, pcn: pcn, group_id: group_id }
@@ -14,7 +14,7 @@ describe 'Indicators' do
     let(:token_id) { 'faketoken' }
     let!(:api_request) do
       stub_request(:post, uri)
-        .with(body: hash_including(post_data))
+        .with(body: hash_including(post_data), basic_auth: [api_id, api_secret])
         .to_return({})
     end
     let(:post_data) { Hash prescription:  prescription_payload }
@@ -63,7 +63,7 @@ describe 'Indicators' do
 
       before do
         stub_request(:post, uri)
-          .with(body: hash_including(post_data))
+          .with(body: hash_including(post_data), basic_auth: [api_id, api_secret])
           .to_return(status: 200, body: { prescription: prescription_response }.to_json)
       end
 
@@ -77,11 +77,11 @@ describe 'Indicators' do
   end
 
   describe '#search_indicators' do
-    let(:uri) { "https://#{api_id}:#{api_secret}@api.covermymeds.com/indicators/search/?v=#{version}" }
+    let(:uri) { "https://api.covermymeds.com/indicators/search/?v=#{version}" }
     let(:token_id) { 'faketoken' }
     let!(:api_request) do
       stub_request(:post, uri)
-        .with(body: hash_including(post_data))
+        .with(body: hash_including(post_data), basic_auth: [api_id, api_secret])
         .to_return({})
     end
     let(:post_data) { Hash prescriptions:  prescription_payload }
@@ -122,7 +122,7 @@ describe 'Indicators' do
 
       before do
         stub_request(:post, uri)
-          .with(body: hash_including(post_data))
+          .with(body: hash_including(post_data), basic_auth: [api_id, api_secret])
           .to_return(status: 200, body: { prescriptions: prescription_response }.to_json)
       end
 

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -11,8 +11,8 @@ describe 'Request' do
   describe 'get request' do
     let(:token_id) {'faketokenabcde1'}
     before do
-      stub_request(:post, "https://#{api_id}:#{api_secret}@api.covermymeds.com/requests/search/?v=#{version}")
-      .with(body: { token_ids: [token_id] })
+      stub_request(:post, "https://api.covermymeds.com/requests/search/?v=#{version}")
+      .with(body: { token_ids: [token_id] }, basic_auth: [api_id, api_secret])
       .to_return( status: 200, body: fixture('get_single_request.json'))
     end
 
@@ -32,7 +32,8 @@ describe 'Request' do
     before do
       WebMockStrict.start
 
-      stub_request(:post, "https://#{api_id}:#{api_secret}@api.covermymeds.com/requests/search/?token_ids[]=#{token_ids.first}&token_ids[]=#{token_ids.last}&v=#{version}")
+      stub_request(:post, "https://api.covermymeds.com/requests/search/?token_ids[]=#{token_ids.first}&token_ids[]=#{token_ids.last}&v=#{version}")
+      .with(basic_auth: [api_id, api_secret])
       .to_return( status: 200, body: fixture('get_multiple_requests.json'))
     end
 
@@ -53,7 +54,8 @@ describe 'Request' do
     end
 
     before do
-      stub_request(:post, "https://#{api_id}:#{api_secret}@api.covermymeds.com/requests/?v=#{version}")
+      stub_request(:post, "https://api.covermymeds.com/requests/?v=#{version}")
+      .with(basic_auth: [api_id, api_secret])
       .to_return( status: 201, body: fixture('create_request.json'))
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ end
 require "cover_my_meds"
 require 'rspec'
 require 'rspec/junklet'
-require 'rest-client'
+require 'faraday'
 require 'webmock'
 require 'webmock/rspec'
 require 'pry'

--- a/spec/token_spec.rb
+++ b/spec/token_spec.rb
@@ -9,8 +9,9 @@ describe 'Access Token' do
 
   context 'create token' do
     before do
-      stub_request(:post, "https://#{api_id}:#{api_secret}@api.covermymeds.com/requests/tokens/?request_ids[]=#{request_id}&v=#{version}")
-      .to_return( status: 201, body: fixture('post_token.json'))
+      stub_request(:post, "https://api.covermymeds.com/requests/tokens/?request_ids[]=#{request_id}&v=#{version}")
+        .with(basic_auth: [api_id, api_secret])
+        .to_return( status: 201, body: fixture('post_token.json'))
     end
 
     it 'returns new token' do
@@ -23,8 +24,9 @@ describe 'Access Token' do
   context 'revoke access token' do
     let(:token_id) { 'tikl5sci8q24kfy1h3rb' }
     before do
-      stub_request(:delete, "https://#{api_id}:#{api_secret}@api.covermymeds.com/requests/tokens/#{token_id}?v=#{version}")
-      .to_return( status: 201, body: fixture('post_token.json'))
+      stub_request(:delete, "https://api.covermymeds.com/requests/tokens/#{token_id}?v=#{version}")
+        .with(basic_auth: [api_id, api_secret])
+        .to_return( status: 201, body: fixture('post_token.json'))
     end
 
     it 'returns response' do


### PR DESCRIPTION
This will allow us to swap out the actual http client
library in use as necessary. Some http clients have
better persistent connections, etc. 

For example, in our current environments we see
much better performance using the Typhoeus gem
compared to rest-client.

@chadcf 