### PR TITLE
Follow redirects to better support request-pages as before

### DIFF
--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday_middleware"
-  spec.add_runtime_dependency "faraday-cookie_jar"
   spec.add_runtime_dependency "typhoeus"
   spec.add_runtime_dependency "mime-types"
   spec.add_runtime_dependency "hashie", ">= 3.4.0"

--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "railties"
 
   spec.add_runtime_dependency "faraday", "~> 0.9"
+  spec.add_runtime_dependency "faraday_middleware"
+  spec.add_runtime_dependency "faraday-cookie_jar"
   spec.add_runtime_dependency "typhoeus"
   spec.add_runtime_dependency "mime-types"
   spec.add_runtime_dependency "hashie", ">= 3.4.0"

--- a/lib/cover_my_meds/api_request.rb
+++ b/lib/cover_my_meds/api_request.rb
@@ -1,4 +1,6 @@
 require 'faraday'
+require 'faraday_middleware'
+require 'faraday-cookie_jar'
 require 'typhoeus'
 require 'typhoeus/adapters/faraday'
 require 'json'
@@ -18,9 +20,11 @@ module CoverMyMeds
       headers = params.delete(:headers) || {}
 
       conn = Faraday.new host do |faraday|
-        faraday.request :multipart
-        faraday.request :url_encoded
-        faraday.adapter :typhoeus
+        faraday.request  :multipart
+        faraday.request  :url_encoded
+        faraday.response :follow_redirects
+        faraday.use      :cookie_jar
+        faraday.adapter  :typhoeus
       end
       case auth_type
       when :basic

--- a/lib/cover_my_meds/api_request.rb
+++ b/lib/cover_my_meds/api_request.rb
@@ -1,6 +1,5 @@
 require 'faraday'
 require 'faraday_middleware'
-require 'faraday-cookie_jar'
 require 'typhoeus'
 require 'typhoeus/adapters/faraday'
 require 'json'
@@ -23,7 +22,6 @@ module CoverMyMeds
         faraday.request  :multipart
         faraday.request  :url_encoded
         faraday.response :follow_redirects
-        faraday.use      :cookie_jar
         faraday.adapter  :typhoeus
       end
       case auth_type

--- a/lib/cover_my_meds/version.rb
+++ b/lib/cover_my_meds/version.rb
@@ -1,3 +1,3 @@
 module CoverMyMeds
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end

--- a/spec/request_page_spec.rb
+++ b/spec/request_page_spec.rb
@@ -41,5 +41,19 @@ describe 'Request' do
         expect(request_page.keys).to match_array expected_keys
       end
     end
+
+    context 'a redirect is returned' do
+      before do
+        stub_request(:get, "https://www.example.com/").to_return(status: 200, body: { request_page: { data: "You redirected" } }.to_json)
+        stub_request(:get, "https://api.covermymeds.com/request-pages/#{request_id}?&v=#{version}")
+          .with( headers: { "Authorization" => "Bearer #{api_id}+#{token_id}" })
+          .to_return( status: 302, :headers => { "Location" => "https://www.example.com/" })
+      end
+
+      it 'follows redirects' do
+        request_page = client.get_request_page(request_id, token_id)
+        expect(request_page.data).to eq "You redirected"
+      end
+    end
   end
 end


### PR DESCRIPTION
@chadcf @robertlude Please take a look at this test and approach to see if it's what we want. This should fix a bug introduced with the move to faraday instead of rest-client. If a call to request-pages redirected, previously I believe we would have followed the redirect and returned the parsed json of that result. Before this change I was raising a CoverMyMeds::Error::HTTPError because of the 302 status coming back.