### PR TITLE
Update Gemspec to use safest version of faraday

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 script:
   - bundle exec rspec spec
 rvm:
-  - 2.0.0-p648
   - 2.1.9
   - 2.2.5
   - 2.3.1

--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "railties"
 
-  spec.add_runtime_dependency "faraday", "~> 0.9"
+  spec.add_runtime_dependency "faraday", "~> 0.11"
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_runtime_dependency "typhoeus"
   spec.add_runtime_dependency "mime-types"

--- a/lib/cover_my_meds/version.rb
+++ b/lib/cover_my_meds/version.rb
@@ -1,3 +1,3 @@
 module CoverMyMeds
-  VERSION = "3.1.0"
+  VERSION = "3.1.1"
 end


### PR DESCRIPTION
Update the expectation of the gemspec to be faraday `~> 0.11` to ensure our change, pr https://github.com/lostisland/faraday/pull/652 specifically, for Faraday is used.

Also includes a change to drop ruby 2.0.x support from CI since the dependencies are currently incompatible, as CI indicated on the build for 99790d7:

> nokogiri-1.7.0.1 requires ruby version >= 2.1.0, which is incompatible with the current version, ruby 2.0.0p648