### PR TITLE
Support for the RESTful PATCH method.

### DIFF
--- a/lib/cover_my_meds.rb
+++ b/lib/cover_my_meds.rb
@@ -9,6 +9,7 @@ module CoverMyMeds
   GET    = 'get'.freeze
   POST   = 'post'.freeze
   PUT    = 'put'.freeze
+  PATCH  = 'patch'.freeze
   DELETE = 'delete'.freeze
 
   def self.version

--- a/lib/cover_my_meds/version.rb
+++ b/lib/cover_my_meds/version.rb
@@ -1,3 +1,3 @@
 module CoverMyMeds
-  VERSION = "3.1.1"
+  VERSION = "3.2.0"
 end

--- a/spec/covermymeds_api_spec.rb
+++ b/spec/covermymeds_api_spec.rb
@@ -4,4 +4,26 @@ describe CoverMyMeds do
   it 'has a version number' do
     expect(CoverMyMeds::VERSION).not_to be nil
   end
+
+  describe 'supports RESTful methods' do
+    it 'has a GET constant' do
+      expect(CoverMyMeds::GET).to eq 'get'
+    end
+
+    it 'has a POST constant' do
+      expect(CoverMyMeds::POST).to eq 'post'
+    end
+
+    it 'has a PUT constant' do
+      expect(CoverMyMeds::PUT).to eq 'put'
+    end
+
+    it 'has a PATCH constant' do
+      expect(CoverMyMeds::PATCH).to eq 'patch'
+    end
+
+    it 'has a DELETE constant' do
+      expect(CoverMyMeds::DELETE).to eq 'delete'
+    end
+  end
 end


### PR DESCRIPTION
Adds the missing RESTful method for downstream support. Specs added to verify that all expected RESTful methods are supported.

![stan](https://cloud.githubusercontent.com/assets/397531/23075108/45303b40-f509-11e6-97b7-82578c2af27a.gif)