### PR TITLE
Add rxnorm and pharmacy as parameters to indicators create

### DIFF
--- a/lib/cover_my_meds/client/indicators.rb
+++ b/lib/cover_my_meds/client/indicators.rb
@@ -4,8 +4,8 @@ module CoverMyMeds
 
     CURRENT_VERSION = 1
 
-    def post_indicators(prescription: prescription(), patient: patient(), payer: {}, prescriber: {}, version: CURRENT_VERSION)
-      params = { prescription: prescription, prescriber: prescriber, patient: patient, payer: payer }
+    def post_indicators(prescription: prescription(), patient: patient(), payer: {}, prescriber: {}, rxnorm: nil, version: CURRENT_VERSION)
+      params = { prescription: prescription, prescriber: prescriber, patient: patient, payer: payer, rxnorm: rxnorm }
       data = indicators_request POST, params: { v: version, headers: { content_type: "application/json" } } do
         params.to_json
       end

--- a/lib/cover_my_meds/client/indicators.rb
+++ b/lib/cover_my_meds/client/indicators.rb
@@ -4,8 +4,8 @@ module CoverMyMeds
 
     CURRENT_VERSION = 1
 
-    def post_indicators(prescription: prescription(), patient: patient(), payer: {}, prescriber: {}, rxnorm: nil, version: CURRENT_VERSION)
-      params = { prescription: prescription, prescriber: prescriber, patient: patient, payer: payer, rxnorm: rxnorm }
+    def post_indicators(prescription: prescription(), patient: patient(), payer: {}, prescriber: {}, pharmacy: {}, rxnorm: nil, version: CURRENT_VERSION)
+      params = { prescription: prescription, prescriber: prescriber, patient: patient, payer: payer, pharmacy: pharmacy, rxnorm: rxnorm }
       data = indicators_request POST, params: { v: version, headers: { content_type: "application/json" } } do
         params.to_json
       end

--- a/lib/cover_my_meds/version.rb
+++ b/lib/cover_my_meds/version.rb
@@ -1,3 +1,3 @@
 module CoverMyMeds
-  VERSION = "3.2.0"
+  VERSION = "3.2.1"
 end

--- a/spec/indicator_spec.rb
+++ b/spec/indicator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Indicators' do
-  junklet :api_id, :api_secret, :bin, :pcn, :group_id
+  junklet :api_id, :api_secret, :bin, :pcn, :group_id, :name, :npi
   let(:version) { 1 }
   let(:uri) { "https://api.covermymeds.com/indicators/?v=#{version}" }
   let(:client) { CoverMyMeds::Client.new(api_id, api_secret) }
@@ -9,6 +9,7 @@ describe 'Indicators' do
   let(:payer_payload) { Hash bin: bin, pcn: pcn, group_id: group_id }
   let(:patient_payload) { { last_name: 'Doe' } }
   let(:prescriber_payload) { Hash npi:  '1234567890' }
+  let(:pharmacy_payload) { Hash name: name, npi: npi }
   let(:rxnorm) { '1234567' }
 
   describe '#post_indicators' do
@@ -60,6 +61,14 @@ describe 'Indicators' do
     let(:post_data) { Hash prescription: prescription_payload, patient: patient_payload, payer: payer_payload, prescriber: prescriber_payload, rxnorm: rxnorm }
     it 'has payer data in the request' do
       client.post_indicators(prescription: prescription_payload, patient: patient_payload, payer: payer_payload, prescriber: prescriber_payload, rxnorm: rxnorm)
+      expect(api_request).to have_been_requested
+    end
+  end
+
+  context 'when given prescription, prescriber, patient, payer, rxnorm, and pharmacy data' do
+    let(:post_data) { Hash prescription: prescription_payload, patient: patient_payload, payer: payer_payload, prescriber: prescriber_payload, pharmacy: pharmacy_payload, rxnorm: rxnorm }
+    it 'has payer data in the request' do
+      client.post_indicators(prescription: prescription_payload, patient: patient_payload, payer: payer_payload, prescriber: prescriber_payload, pharmacy: pharmacy_payload, rxnorm: rxnorm)
       expect(api_request).to have_been_requested
     end
   end

--- a/spec/indicator_spec.rb
+++ b/spec/indicator_spec.rb
@@ -8,7 +8,8 @@ describe 'Indicators' do
   let(:prescription_payload) { Hash drug_id: '12345' }
   let(:payer_payload) { Hash bin: bin, pcn: pcn, group_id: group_id }
   let(:patient_payload) { { last_name: 'Doe' } }
-  let(:prescriber_payload) { Hash npi: '1234567890' }
+  let(:prescriber_payload) { Hash npi:  '1234567890' }
+  let(:rxnorm) { '1234567' }
 
   describe '#post_indicators' do
     let(:token_id) { 'faketoken' }
@@ -54,6 +55,14 @@ describe 'Indicators' do
         expect(api_request).to have_been_requested
       end
     end
+
+  context 'when given prescription, prescriber, patient, payer, and rxnorm data' do
+    let(:post_data) { Hash prescription: prescription_payload, patient: patient_payload, payer: payer_payload, prescriber: prescriber_payload, rxnorm: rxnorm }
+    it 'has payer data in the request' do
+      client.post_indicators(prescription: prescription_payload, patient: patient_payload, payer: payer_payload, prescriber: prescriber_payload, rxnorm: rxnorm)
+      expect(api_request).to have_been_requested
+    end
+  end
 
     context 'when additional data is included in the response body' do
       #response from indicators API


### PR DESCRIPTION
RxBC requires that rxnorm and pharmacy be passed into their API in certain cases. This PR allows this to happen.