### PR TITLE
bumping version to 3.2.2

### DIFF
--- a/lib/cover_my_meds/version.rb
+++ b/lib/cover_my_meds/version.rb
@@ -1,3 +1,3 @@
 module CoverMyMeds
-  VERSION = "3.2.1"
+  VERSION = "3.2.2"
 end


### PR DESCRIPTION
this change will not affect the gem at all in the public space, as it was deployed correctly to rubygems.org, but internally, the deployment of 3.2.1 did not include the actual changes that happened with the 3.2.1 release for some reason.

In order for our apps to obtain that content, the version will need to be bumped and deployed internally. 