### PR TITLE
locked ffi version to 1.9.21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,6 @@ if RUBY_VERSION < '2.2'
   gem 'rack', '~> 1.6.0', group: :test
 end
 
+gem "ffi", "= 1.9.21"
+
 gemspec

--- a/lib/cover_my_meds/version.rb
+++ b/lib/cover_my_meds/version.rb
@@ -1,3 +1,3 @@
 module CoverMyMeds
-  VERSION = "3.2.2"
+  VERSION = "3.2.3"
 end


### PR DESCRIPTION
When using ffi version 1.9.23, which is installed as a dependency of the typheous gem, we are seeing segmentation faults when trying to run specs. This is a known issue with this version of ffi: https://github.com/ffi/ffi/issues/621

This PR locks down the ffi gem version to 1.9.21.