### PR TITLE
Allow disabling hashie log when initializing client

### DIFF
--- a/lib/cover_my_meds/client.rb
+++ b/lib/cover_my_meds/client.rb
@@ -40,5 +40,8 @@ module CoverMyMeds
       @default_host ||= "https://api.covermymeds.com"
     end
 
+    def disable_hashie_log
+      Hashie.logger = Logger.new('/dev/null')
+    end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -49,4 +49,12 @@ describe CoverMyMeds::Client do
     client = CoverMyMeds::Client.new(username)
     expect(client.default_host).to eq("https://api.covermymeds.com")
   end
+
+  describe '#disable_hashie_log' do
+    it 'sets the Hashie logger' do
+      client = CoverMyMeds::Client.new(username)
+      client.disable_hashie_log
+      expect(Hashie.logger.instance_variable_get(:@logdev).filename).to eq('/dev/null')
+    end
+  end
 end


### PR DESCRIPTION
This will save on log space and noise by preventing these kinds of
warnings from being dumped into the Rails log.
```
You are setting a key that conflicts with a built-in method Hashie::Mash#method defined in Kernel. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
```