### PR TITLE
Ksearfos render correct error

### DIFF
--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "typhoeus"
   spec.add_runtime_dependency "mime-types"
   spec.add_runtime_dependency "hashie", ">= 3.4.0"
-  spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency "activesupport", '>= 4.2.2'
 end

--- a/lib/cover_my_meds/api_request.rb
+++ b/lib/cover_my_meds/api_request.rb
@@ -17,6 +17,8 @@ module CoverMyMeds
     def request(http_method, host, path, params={}, auth_type = :basic, &block)
       params  = params.symbolize_keys
       headers = params.delete(:headers) || {}
+      uri = "#{host}#{path}"
+      uri << "?#{params.to_query}" if params.present?
 
       conn = Faraday.new host do |faraday|
         faraday.request  :multipart
@@ -38,7 +40,7 @@ module CoverMyMeds
         request.headers.merge! headers
         request.body = block_given? ? yield : {}
       end
-      raise Error::HTTPError.new(response.status, response.body, http_method, conn) unless response.success?
+      raise Error::HTTPError.new(response.status, response.body, http_method, uri) unless response.success?
 
       parse_response response
     end

--- a/lib/cover_my_meds/api_request.rb
+++ b/lib/cover_my_meds/api_request.rb
@@ -17,8 +17,6 @@ module CoverMyMeds
     def request(http_method, host, path, params={}, auth_type = :basic, &block)
       params  = params.symbolize_keys
       headers = params.delete(:headers) || {}
-      uri = "#{host}#{path}"
-      uri << "?#{params.to_query}" if params.present?
 
       conn = Faraday.new host do |faraday|
         faraday.request  :multipart
@@ -40,7 +38,7 @@ module CoverMyMeds
         request.headers.merge! headers
         request.body = block_given? ? yield : {}
       end
-      raise Error::HTTPError.new(response.status, response.body, http_method, uri) unless response.success?
+      raise Error::HTTPError.new(response.status, response.body, http_method, url(host, path, params)) unless response.success?
 
       parse_response response
     end
@@ -50,6 +48,12 @@ module CoverMyMeds
       JSON.parse(response.body)
     rescue JSON::ParserError
       response.body
+    end
+
+    def url(host, path, params)
+      "#{host}#{path}".tap do |url|
+        url << "?#{params.to_query}" if params.present?
+      end
     end
   end
 end

--- a/lib/cover_my_meds/error.rb
+++ b/lib/cover_my_meds/error.rb
@@ -2,22 +2,22 @@ module CoverMyMeds
   module Error
     class HTTPError < StandardError
 
-      def initialize status, message, http_method, rest_resource
+      def initialize status, message, http_method, url
         @status = status
         @error_json = message
         @http_method = http_method
-        @rest_resource = rest_resource
+        @url = url
       end
 
       def message
         <<-EOS.gsub(/^ {10}/, "")
           #{@status}: #{@error_json}
           in response to:
-          #{@http_method.upcase} #{@rest_resource}
+          #{@http_method.upcase} #{@url}
         EOS
       end
 
-      attr_reader :status, :error_json, :http_method, :rest_resource
+      attr_reader :status, :error_json, :http_method, :url
 
     end
 

--- a/lib/cover_my_meds/version.rb
+++ b/lib/cover_my_meds/version.rb
@@ -1,3 +1,3 @@
 module CoverMyMeds
-  VERSION = "3.2.6"
+  VERSION = "3.2.7"
 end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -4,13 +4,14 @@ module CoverMyMeds
   module Error
     describe HTTPError do
 
-      subject { described_class.new status, error_json, http_method, rest_resource }
+      subject { described_class.new status, error_json, http_method, url }
 
       specify "#message" do
-        expect(subject.message).to eq(
-          "#{status}: #{error_json}\n"+
-          "in response to:\n"+
-          "#{http_method.upcase} #{rest_resource}\n"
+        expect(subject.message).to eq(<<-EOS
+404: {"errors":[{"debug":"Nothing to see here, move along."}]}
+in response to:
+POST https://<url>/<route>/?<params>&v=<version>
+        EOS
         )
       end
 
@@ -26,8 +27,8 @@ module CoverMyMeds
         expect(subject.http_method).to eq(http_method)
       end
 
-      specify "#rest_resource" do
-        expect(subject.rest_resource).to eq(rest_resource)
+      specify "#url" do
+        expect(subject.url).to eq(url)
       end
 
       let(:status) { 404 }
@@ -38,8 +39,7 @@ module CoverMyMeds
 
       let(:http_method) { 'post' }
 
-      let(:rest_resource) { 'https://<url>/<route>/?<params>&v=<version>' }
-
+      let(:url) { 'https://<url>/<route>/?<params>&v=<version>' }
     end
   end
 end

--- a/spec/lib/cover_my_meds/api_request_spec.rb
+++ b/spec/lib/cover_my_meds/api_request_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+class TestClass
+  include CoverMyMeds::ApiRequest
+end
+
+RSpec.describe CoverMyMeds::ApiRequest do
+  subject { TestClass.new }
+  let(:host) { 'https://www.example.com' }
+  let(:path) { '/very_important_path' }
+  let(:params) { Hash(v: 1, key1: 'value1', key2: 'value2') }
+
+  describe '#url' do
+    it 'is the url constructed from the host and path' do
+      expect(subject.url(host, path, {})).to eq 'https://www.example.com/very_important_path'
+    end
+
+    context 'when there are query params' do
+      it 'includes the params, listed in alphabetical order' do
+        expect(subject.url(host, path, params)).to eq 'https://www.example.com/very_important_path?key1=value1&key2=value2&v=1'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Awhile ago (like, version 2) we passed a `RestClient::Resource` object to the error when we created it.  This apparently had a nice, easy `#to_s` method that returned the URL.  And it was good.  (Seriously, you can view the implementation of `RestClient::Resource#to_s` [here](https://www.rubydoc.info/gems/rest-client/1.6.1/RestClient/Resource#to_s-instance_method) and see that it literally returns the URL.)

But somewhere along the lines (like, version 3) we decided to pass a `Faraday::Connection` object instead.  Calling `#to_s` on this object basically displays `#<Faraday::Connection:0x00000007569940>` which is, at best, not very helpful, and at worst, not the URL at all.

Unfortunately, some of the repos that use CoverMyMeds actually verify that the correct error message is being displayed, and these specs are now broken.  See appeals-api.  I figured it was probably important to someone that the URL be included in the error message instead of the Faraday instance, and decided to fix it.

Consequently, I updated the `ApiRequest` class, which is the object which creates and raises the error, to pass the url directly instead of the Faraday object.  I also updated the spec to expect the URL to be passed -- there were no specs to check for the right kind of object or appropriate error message before.

I also modified the error class and its specs slightly, to stop calling the variable `rest_resource` and start calling it `url`, since that is what it is now.

## Testing
I tested the updated version of the gem along with the appeals-api rails 5 upgrade, which originally found the problem.  I had a handful of request specs failing because cover_my_meds was producing an incorrect error message on failure.  With these changes in place, those tests now pass.

This is extra good as it is essentially verifying that the tests I added are testing the right thing.

## Risk

This is a low-risk change.  Not only is it a pretty small change that has been tested for accuracy, but this is a gem, so if people find there is an issue with this particular gem version, they can just not use it.  (But they won't because it's been tested and I know it works!)  It's also made less risky by the fact that the gem currently does not behave as expected, so if this change does not correct the issue, that won't really be a change over the current status quo.