### PR TITLE
remove ffi as direct dependency

### DIFF
--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "faraday", "~> 0.11"
   spec.add_runtime_dependency "faraday_middleware"
-  spec.add_runtime_dependency "ffi", "= 1.9.25"
   spec.add_runtime_dependency "typhoeus"
   spec.add_runtime_dependency "mime-types"
   spec.add_runtime_dependency "hashie", ">= 3.4.0"


### PR DESCRIPTION
It doesn't seem that this gem depends on ffi directly.
Can ffi be removed from the gemspec to allow ffi to be updated independently of this gem?
It's problematic as is because ffi is being locked to an exact version by this gem, blocking a client's ability to update ffi (for example, to resolve a CVE).