### PR TITLE
Add a spec task, use pessimistic versioning on all runtime dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,5 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
+RSpec::Core::RakeTask.new(:spec)
+task :default => [:spec]

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,1 @@
 require "bundler/gem_tasks"
-require "rspec/core/rake_task"
-
-RSpec::Core::RakeTask.new(:spec)
-task :default => [:spec]

--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rspec", ">= 3.2"
-  spec.add_development_dependency "rspec-junklet", ">= 2.0"
+  spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_development_dependency "rspec-junklet", "~> 2.0"
   spec.add_development_dependency "webmock", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "pry"
@@ -28,10 +28,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "railties"
 
-  spec.add_runtime_dependency "faraday", ">= 1.0", "< 2.0"
+  spec.add_runtime_dependency "faraday", "~> 1.0"
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_runtime_dependency "typhoeus"
   spec.add_runtime_dependency "mime-types"
-  spec.add_runtime_dependency "hashie", ">= 3.4.0"
+  spec.add_runtime_dependency "hashie", "~> 3.4.0"
   spec.add_runtime_dependency "activesupport", ">= 4.2.2"
 end

--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday", "~> 1.0"
   spec.add_runtime_dependency "faraday_middleware", "~> 1.2"
   spec.add_runtime_dependency "typhoeus", "~> 1.4"
-  spec.add_runtime_dependency "mime-types", "~> 3.4.1"
-  spec.add_runtime_dependency "hashie", "~> 3.4.0"
+  spec.add_runtime_dependency "mime-types", "~> 3.4"
+  spec.add_runtime_dependency "hashie", "~> 3.4"
   spec.add_runtime_dependency "activesupport", ">= 4.2.2"
 end

--- a/cover_my_meds.gemspec
+++ b/cover_my_meds.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "railties"
 
   spec.add_runtime_dependency "faraday", "~> 1.0"
-  spec.add_runtime_dependency "faraday_middleware"
-  spec.add_runtime_dependency "typhoeus"
-  spec.add_runtime_dependency "mime-types"
+  spec.add_runtime_dependency "faraday_middleware", "~> 1.2"
+  spec.add_runtime_dependency "typhoeus", "~> 1.4"
+  spec.add_runtime_dependency "mime-types", "~> 3.4.1"
   spec.add_runtime_dependency "hashie", "~> 3.4.0"
   spec.add_runtime_dependency "activesupport", ">= 4.2.2"
 end


### PR DESCRIPTION
Currently there's no spec task, so this PR adds one. This will make it easier for folks like me to clone and test things locally. It will also be useful for github actions.

*Update*: As I've learned, users can just run `bundle exec rspec`, though this does provide a default task as well. I can remove if you find it unnecessary.

I also applied pessimistic versioning on the runtime dependencies and a couple of the dev dependencies. Currently, e.g. hashie, was too loose IMHO, as it has already had two major revisions since the currently defined 3.4.x.

Incidentally, all specs currently pass after applying this change, regenerating a local Gemfile.lock, and running `rake spec`.